### PR TITLE
[TRIBE-68] 토큰이 유효한지 확인하는 공통 로직 추가

### DIFF
--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -6,13 +6,14 @@ from sqlalchemy.orm import Session
 
 from app.core import get_db
 from app.dtos import auth, naver
-from app.services import AuthService, NaverService, UserService
+from app.services import AuthService, NaverService, TokenService, UserService
 
-auth_router = APIRouter()
+auth_router = APIRouter(tags=["auth"])
 
 auth_service = AuthService()
 naver_service = NaverService()
 user_service = UserService()
+token_service = TokenService()
 
 
 @auth_router.get("/start")
@@ -115,7 +116,11 @@ def sign_up(
 
 
 @auth_router.post("/refresh-token")
-def refresh_token(token: auth.Token, request: Request, db: Session = Depends(get_db)):
+def refresh_token(
+    request: Request,
+    token: str = Depends(token_service.validate_token),
+    db: Session = Depends(get_db),
+):
     """
     요청 정보에서 refresh_token을 받아와 access_token을 갱신하는 요청입니다.
     """

--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -5,7 +5,7 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.core import get_db
-from app.dtos import auth, naver
+from app.dtos import naver
 from app.services import AuthService, NaverService, TokenService, UserService
 
 auth_router = APIRouter(tags=["auth"])

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -2,5 +2,13 @@ from .config import Config, EnvTypes
 from .database import Database
 from .database import bootstrap as database_bootstrap
 from .database import get_db
+from .openapi import OpenAPI
 
-__all__ = ["Config", "EnvTypes", "Database", "get_db", "database_bootstrap"]
+__all__ = [
+    "Config",
+    "EnvTypes",
+    "Database",
+    "get_db",
+    "database_bootstrap",
+    "OpenAPI",
+]

--- a/app/core/openapi.py
+++ b/app/core/openapi.py
@@ -1,0 +1,41 @@
+from fastapi.openapi.utils import get_openapi
+
+
+class OpenAPI:
+    def __init__(self, app):
+        self.app = app
+        self.exclude_paths = [
+            "/refresh-token",
+        ]
+
+    def is_in_exclude_path(self, path: str):
+        for exclude_path in self.exclude_paths:
+            if exclude_path in path:
+                return True
+        return False
+
+    def get_customized_openapi(self):
+        if self.app.openapi_schema:
+            return self.app.openapi_schema
+
+        openapi_schema = get_openapi(
+            title="트라이브 API 문서", version="1.0.0", routes=self.app.routes
+        )
+
+        openapi_schema["components"]["securitySchemes"] = {
+            "BearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+            }
+        }
+
+        # 특정 경로를 제외하고 BearerAuth 적용
+        for path in openapi_schema["paths"]:
+            if self.is_in_exclude_path(path):
+                for method in openapi_schema["paths"][path]:
+                    openapi_schema["paths"][path][method]["security"] = [
+                        {"BearerAuth": []}
+                    ]
+        self.app.openapi_schema = openapi_schema
+        return self.app.openapi_schema

--- a/app/core/openapi.py
+++ b/app/core/openapi.py
@@ -5,14 +5,17 @@ class OpenAPI:
     def __init__(self, app):
         self.app = app
         self.exclude_paths = [
-            "/refresh-token",
+            "/auth/start",
+            "/auth/callback",
+            "/auth/naver/user_info",
+            "/auth/sign-up",
         ]
 
     def is_in_exclude_path(self, path: str):
         for exclude_path in self.exclude_paths:
             if exclude_path in path:
-                return True
-        return False
+                return False
+        return True
 
     def get_customized_openapi(self):
         if self.app.openapi_schema:

--- a/app/main.py
+++ b/app/main.py
@@ -2,13 +2,16 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
-from app.core import Config, database_bootstrap
+from app.core import Config, OpenAPI, database_bootstrap
 from app.routers.router import main_router
 
 # 데이터베이스 설정
 database_bootstrap()
 
 app = FastAPI()
+
+# 스웨거 설정
+app.openapi = OpenAPI(app).get_customized_openapi
 
 
 # CORS 설정 추가

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,5 +1,5 @@
-from .auth import AuthService, NaverService
+from .auth import AuthService, NaverService, TokenService
 from .badge_service import BadgeService
 from .user_service import UserService
 
-__all__ = ["AuthService", "NaverService", "BadgeService", "UserService"]
+__all__ = ["AuthService", "NaverService", "BadgeService", "UserService", "TokenService"]

--- a/app/services/auth/__init__.py
+++ b/app/services/auth/__init__.py
@@ -1,4 +1,5 @@
 from .auth_service import AuthService
 from .naver_service import NaverService
+from .token_service import TokenService
 
-__all__ = ["AuthService", "NaverService"]
+__all__ = ["AuthService", "NaverService", "TokenService"]

--- a/app/services/auth/token_service.py
+++ b/app/services/auth/token_service.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timezone
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jwt.exceptions import InvalidTokenError
+from sqlalchemy.orm import Session
+
+from app.core import Config, get_db
+from app.repositories import AuthRepository
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+class TokenService:
+    def __init__(self):
+        self.auth_repository = AuthRepository()
+
+    def decode_token(self, token: str):
+        print(f"decode_token: {token}, {Config.Token.ALGORITHM}")
+        return jwt.decode(
+            token, Config.APP_SECRET_KEY, algorithms=[Config.Token.ALGORITHM]
+        )
+
+    def is_token_expired(self, exp: int):
+        """
+        토큰 만료 여부를 확인하는 함수입니다.
+        """
+        current_time = datetime.now(timezone.utc).timestamp()
+        return current_time > exp
+
+    def validate_token(self, token: str = Depends(oauth2_scheme)):
+        try:
+            payload = self.decode_token(token)
+
+            exp = payload.get("exp")
+
+            if self.is_token_expired(exp):
+                return HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="토큰이 유효하지 않거나 만료되었습니다.",
+                )
+
+            return token
+        except InvalidTokenError as e:
+            print(f"오류? {e}")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="토큰이 유효하지 않거나 만료되었습니다.",
+            )


### PR DESCRIPTION
[![TRIBE-68](https://badgen.net/badge/JIRA/TRIBE-68/green?icon=jira)](https://tribe-forus.atlassian.net/browse/TRIBE-68) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tribe-org&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[OpenAPI](https://github.com/Tribe-org/server/compare/feature/tribe-68?expand=1#diff-3bbe1f2e6b07ec86b8968078a341baf561b66513cf941e6de08f648178932525R7) 코드의 `exclude_paths` 배열에 반드시 `access_token`을 전달해야 할 필요가 없는 라우트는 제외하도록 경로를 추가할 수 있다.

그 외에는, 아래 코드처럼 의존성을 추가해야 한다.
```py
@auth_router.post("/refresh-token")
def refresh_token(
    # token_service의 validate_token을 Depends로 추가해야 한다.
    token: str = Depends(token_service.validate_token),
    ...
):
   ...
```