### PR TITLE
[TRIBE-79] refactor: 컨트롤러와 서비스 계층 역할 분리 및  URL 중복 슬래시 제거

### DIFF
--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -1,10 +1,8 @@
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi import APIRouter, Form, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, Response
-from sqlalchemy.orm import Session
-
-from app.core import Config, get_db
+from app.core import Config
 from app.core.database import session_scope
 from app.dtos import naver
 from app.services import AuthService, NaverService, TokenService, UserService
@@ -21,88 +19,99 @@ token_service = TokenService()
 @auth_router.get("/start")
 def auth_start():
     url = naver_service.auth_start()
+    print(f"[DEBUG] Redirecting to URL: {url}")
     return RedirectResponse(url)
 
 
 @auth_router.get("/callback")
-async def auth_callback(
-    code: str, state: str, request: Request, db: Session = Depends(get_db)
-):
-    with session_scope() as session:
-        # session 시작
-        print(session)
-        pass
+async def auth_callback(code: str, state: str, request: Request):
+    print(f"[DEBUG] Callback received with code: {code}, state: {state}")
     if not code:
+        print("[ERROR] Code is not provided")
         raise HTTPException(status_code=400, detail="code is not provided")
     if not state:
+        print("[ERROR] State is not provided")
         raise HTTPException(status_code=400, detail="state is not provided")
 
+    print("[DEBUG] Calling NaverService auth_callback...")
     response = await naver_service.auth_callback(code, state)
+    print(f"[DEBUG] Naver auth response: {response}")
 
     access_token = response.get("access_token")
-
     if not access_token:
-        raise HTTPException(status_code=400, detail="access_token이 필요합니다.")
+        print("[ERROR] Access token is missing in the response")
+        raise HTTPException(status_code=400, detail="access_token가 필요합니다.")
 
+    print(f"[DEBUG] Access token received: {access_token}")
     generate_url = make_url(Config.CLIENT_URL)
+    print(f"[DEBUG] Generated URL: {generate_url}")
 
-    # 네이버 회원정보 가져오기
+    print("[DEBUG] Fetching user information from Naver...")
     naver_user_info = await naver_service.user_me(access_token)
+    print(f"[DEBUG] Naver user info: {naver_user_info}")
+
     birthday = datetime.strptime(
         f"{naver_user_info.birthyear}-{naver_user_info.birthday}", "%Y-%m-%d"
     )
+    print(f"[DEBUG] User birthday: {birthday}")
 
-    # 사용자가 14세 미만이면 네이버 로그인을 다시 해제
+    # 사용자가 14세 미만인지 확인
     if not check_age(birthday=birthday, age=14):
+        print("[DEBUG] User is under 14 years old, revoking token...")
         delete_result = await naver_service.delete_token(access_token)
-
-        # 네이버 연동 해제 성공 시
         if delete_result:
+            print("[DEBUG] Token revoked successfully")
             params = {"message": "14세 미만은 가입할 수 없습니다."}
-            url = generate_url("/login", params=params)
+            url = generate_url("login", params={"access_token": "", "code": code})
+            print(f"[DEBUG] Redirecting to: {url}")
+            return RedirectResponse(url, status_code=301)
 
-        response = RedirectResponse(url, status_code=301)
-        return response
+    print("[DEBUG] Checking if user exists in the database...")
+    with session_scope() as session:
+        user_exist = user_service.user_exists(session, email=naver_user_info.email)
+        print(f"[DEBUG] User exists: {user_exist}")
 
-    # 회원 정보를 조회
-    user_exist = user_service.user_exists(db, email=naver_user_info.email)
+        if user_exist:
+            print("[DEBUG] Signing in the user...")
+            access_token, refresh_token = auth_service.sign_in(naver_user_info, session)
 
-    if user_exist:
-        access_token, refresh_token = auth_service.sign_in(naver_user_info, db)
+            params = {"access_token": access_token}
+            url = generate_url("login", params=params)
+            print(f"[DEBUG] Redirecting to: {url}")
 
-        params = {"access_token": access_token}
-        url = generate_url("/login", params=params)
+            response = RedirectResponse(url, status_code=301)
+            response.set_cookie(
+                key="refresh_token",
+                value=refresh_token,
+                httponly=True,
+                samesite="lax",
+            )
+            return response
+        else:
+            print("[DEBUG] User does not exist, redirecting to sign-up...")
+            request.session[code] = naver_user_info.model_dump()
 
-        response = RedirectResponse(url, status_code=301)
-        response.set_cookie(
-            key="refresh_token",
-            value=refresh_token,
-            httponly=True,
-            samesite="lax",
-        )
-        return response
-    else:
-        # 회원 정보가 없으면 세션에 로그인 정보 저장 후, 회원가입 페이지로 리디렉션
-        # 네이버 회원 정보를 세션에 저장
-        request.session[code] = naver_user_info.model_dump()
+            params = {"access_token": "", "code": code}
+            url = generate_url("login", params=params)
+            print(f"[DEBUG] Redirecting to: {url}")
 
-        params = {"access_token": "", "code": code}
-        url = generate_url("/login", params=params)
-
-        response = RedirectResponse(url, status_code=301)
-        return response
+            return RedirectResponse(url, status_code=301)
 
 
 @auth_router.post("/naver/user_info")
 def get_naver_user_info(dto: naver.NaverUserInfoWithCodeDTO, request: Request):
     code = dto.code
+    print(f"[DEBUG] Received code: {code}")
 
     if not code:
+        print("[ERROR] Code is missing")
         raise HTTPException(status_code=400, detail="code가 필요합니다.")
 
     naver_user_info: naver.NaverUserDTO = request.session.get(code)
+    print(f"[DEBUG] Naver user info from session: {naver_user_info}")
 
     if not naver_user_info:
+        print("[ERROR] Session is expired or invalid")
         raise HTTPException(
             status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
         )
@@ -111,67 +120,74 @@ def get_naver_user_info(dto: naver.NaverUserInfoWithCodeDTO, request: Request):
 
 
 @auth_router.post("/sign-up")
-def sign_up(
-    request: Request,
-    code: str = Form(...),
-    db: Session = Depends(get_db),
-):
-    naver_user_info: naver.NaverUserDTO = request.session.get(code)
+def sign_up(request: Request, code: str = Form(...)):
+    print(f"[DEBUG] Sign-up received with code: {code}")
+    naver_user_info = request.session.get(code)
+    print(f"[DEBUG] Naver user info from session: {naver_user_info}")
 
     if not naver_user_info:
+        print("[ERROR] Session is expired or invalid")
         raise HTTPException(
             status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
         )
 
-    # 회원가입 진행
-    new_tribe_user = auth_service.sign_up(
-        db, naver.NaverUserDTO(**naver_user_info)
-    )  # noqa
+    with session_scope() as session:
+        print("[DEBUG] Signing up user...")
+        new_tribe_user = auth_service.sign_up(
+            session, naver.NaverUserDTO(**naver_user_info)
+        )
+        print(f"[DEBUG] New user created: {new_tribe_user}")
 
-    # 회원가입이 끝났으면 세션 초기화
-    request.session.clear()
+        print("[DEBUG] Clearing session...")
+        request.session.clear()
 
     return new_tribe_user
 
 
 @auth_router.post("/token/refresh")
-def refresh_token(
-    request: Request,
-    token: str = Depends(token_service.validate_token),
-    db: Session = Depends(get_db),
-):
-    """
-    요청 정보에서 refresh_token을 받아와 access_token을 갱신하는 요청입니다.
-    """
-    is_expired = auth_service.validate_token(token=token, db=db)
+def refresh_token(request: Request):
+    print("[DEBUG] Refresh token endpoint called")
+    refresh_token = request.cookies.get("refresh_token")
+    print(f"[DEBUG] Refresh token from cookies: {refresh_token}")
 
-    if is_expired:
+    if not refresh_token:
+        print("[ERROR] Refresh token is missing")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="토큰이 유효하지 않거나 만료되었습니다.",
+            detail="Refresh token이 필요합니다.",
         )
 
-    # access_token 다시 발급하기
-    refresh_token = request.cookies.get("refresh_token")
-    new_access_token = auth_service.issue_access_token(refresh_token)
+    with session_scope() as session:
+        print("[DEBUG] Validating token...")
+        is_expired = auth_service.validate_token(token=refresh_token, db=session)
 
-    return {"access_token": new_access_token}
+        if is_expired:
+            print("[ERROR] Token is expired or invalid")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="토큰이 유효하지 않거나 만료되었습니다.",
+            )
+
+        new_access_token = auth_service.issue_access_token(refresh_token)
+        print(f"[DEBUG] New access token issued: {new_access_token}")
+
+        return {"access_token": new_access_token}
 
 
 @auth_router.post("/token/validate")
-def validate_token(
-    token: str = Depends(token_service.validate_token),
-    db: Session = Depends(get_db),  # noqa
-):
-    """
-    헤더에서 access_token을 받아와 토큰이 유효한지 검사하는 요청입니다.
-    """
-    is_expired = auth_service.validate_token(token=token, db=db)
+def validate_token(token: str):
+    print(f"[DEBUG] Validate token called with token: {token}")
 
-    if is_expired:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="토큰이 유효하지 않거나 만료되었습니다.",
-        )
+    with session_scope() as session:
+        print("[DEBUG] Validating token in the database...")
+        is_expired = auth_service.validate_token(token=token, db=session)
 
-    return Response(status_code=status.HTTP_200_OK)
+        if is_expired:
+            print("[ERROR] Token is expired or invalid")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="토큰이 유효하지 않거나 만료되었습니다.",
+            )
+
+        print("[DEBUG] Token is valid")
+        return Response(status_code=status.HTTP_200_OK)

--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -1,11 +1,9 @@
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi import APIRouter, Form, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, Response
-from sqlalchemy.orm import Session
 
-from app.core import Config, get_db
-from app.core.database import session_scope
+from app.core import Config
 from app.dtos import naver
 from app.services import AuthService, NaverService, TokenService, UserService
 from app.utils import check_age, make_url
@@ -24,33 +22,24 @@ def auth_start():
     return RedirectResponse(url)
 
 @auth_router.get("/callback")
-async def auth_callback(
-    code: str, state: str, request: Request, db: Session = Depends(get_db)
-):
-    with session_scope() as session:
-        # 세션 시작
-        pass
+async def auth_callback(code: str, state: str, request: Request):
 
     if not code:
-        # code가 제공되지 않았을 경우 예외를 발생
         raise HTTPException(status_code=400, detail="code가 제공되지 않았습니다.")
 
     if not state:
-        # state가 제공되지 않았을 경우 예외를 발생
         raise HTTPException(status_code=400, detail="state가 제공되지 않았습니다.")
 
     # 네이버 인증 처리 후 액세스 토큰을 가져오기
     response = await naver_service.auth_callback(code, state)
-
     access_token = response.get("access_token")
 
     if not access_token:
-        # 액세스 토큰이 없을 경우 예외를 발생
         raise HTTPException(status_code=400, detail="access_token이 필요합니다.")
 
     generate_url = make_url(Config.CLIENT_URL)
 
-    # 네이버 사용자 정보를 가져옵니다.
+    # 네이버 사용자 정보를 가져오기
     naver_user_info = await naver_service.user_me(access_token)
     birthday = datetime.strptime(
         f"{naver_user_info.birthyear}-{naver_user_info.birthday}", "%Y-%m-%d"
@@ -60,20 +49,17 @@ async def auth_callback(
     if not check_age(birthday=birthday, age=14):
         delete_result = await naver_service.delete_token(access_token)
 
-        # 네이버 연동 해제 성공 시 처리
         if delete_result:
             params = {"message": "14세 미만은 가입할 수 없습니다."}
             url = generate_url("/login", params=params)
 
-        response = RedirectResponse(url, status_code=301)
-        return response
+            response = RedirectResponse(url, status_code=301)
+            return response
 
-    # 사용자 이메일로 회원 정보를 조회합니다.
-    user_exist = user_service.user_exists(email=naver_user_info.email)
-
-    if user_exist:
+    # 사용자 이메일로 회원 정보 확인 및 처리
+    if user_service.user_exists(email=naver_user_info.email):
         # 사용자 정보가 존재하면 액세스 토큰과 리프레시 토큰을 생성합니다.
-        access_token, refresh_token = auth_service.sign_in(naver_user_info, db)
+        access_token, refresh_token = auth_service.sign_in(naver_user_info)
 
         params = {"access_token": access_token}
         url = generate_url("/login", params=params)
@@ -87,14 +73,16 @@ async def auth_callback(
         )
         return response
     else:
-        # 사용자 정보가 존재하지 않으면 세션에 네이버 사용자 정보를 저장합니다.
-        request.session[code] = naver_user_info.model_dump()
+        try:
+            # 사용자 정보가 존재하지 않으면 회원가입을 처리
+            auth_service.sign_up(naver_user_info)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail="회원가입에 실패했습니다.")
 
         params = {"access_token": "", "code": code}
         url = generate_url("/login", params=params)
 
-        response = RedirectResponse(url, status_code=301)
-        return response
+        return RedirectResponse(url, status_code=301)
 
 @auth_router.post("/naver/user_info")
 def get_naver_user_info(dto: naver.NaverUserInfoWithCodeDTO, request: Request):
@@ -102,39 +90,29 @@ def get_naver_user_info(dto: naver.NaverUserInfoWithCodeDTO, request: Request):
     code = dto.code
 
     if not code:
-        # code가 제공되지 않았을 경우 예외를 발생
+        # code가 제공되지 않았을 경우 예외 발생
         raise HTTPException(status_code=400, detail="code가 필요합니다.")
 
     naver_user_info: naver.NaverUserDTO = request.session.get(code)
 
     if not naver_user_info:
-        # 세션이 만료되었거나 유효하지 않은 경우 예외를 발생
+        # 세션이 만료되었거나 유효하지 않은 경우 예외 발생
         raise HTTPException(
             status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
         )
 
-    # 사용자 정보를 성공적으로 반환
     return naver.NaverUserInfoWithEmailAndNameDTO(**naver_user_info)
 
 @auth_router.post("/sign-up")
-def sign_up(
-    request: Request,
-    code: str = Form(...),
-    db: Session = Depends(get_db),
-):
-    # 네이버 사용자 정보를 세션에서 가져오기
+def sign_up(request: Request, code: str = Form(...)):
     naver_user_info: naver.NaverUserDTO = request.session.get(code)
 
     if not naver_user_info:
-        # 세션이 만료되었거나 유효하지 않은 경우 예외를 발생
         raise HTTPException(
             status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
         )
 
-    # 회원가입 진행
-    new_tribe_user = auth_service.sign_up(
-        db, naver.NaverUserDTO(**naver_user_info)
-    )
+    new_tribe_user = auth_service.sign_up(naver_user_info)
 
     # 회원가입이 완료되면 세션을 초기화
     request.session.clear()
@@ -142,44 +120,25 @@ def sign_up(
     return new_tribe_user
 
 @auth_router.post("/token/refresh")
-def refresh_token(
-    request: Request,
-    token: str = Depends(token_service.validate_token),
-    db: Session = Depends(get_db),
-):
-    """
-    요청 정보에서 refresh_token을 받아와 access_token을 갱신하는 요청
-    """
-    is_expired = auth_service.validate_token(token=token, db=db)
+def refresh_token(request: Request):
+    refresh_token = request.cookies.get("refresh_token")
 
-    if is_expired:
-        # 토큰이 유효하지 않거나 만료된 경우 예외를 발생
+    if not refresh_token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="토큰이 유효하지 않거나 만료되었습니다.",
         )
 
-    # access_token을 다시 발급합니다.
-    refresh_token = request.cookies.get("refresh_token")
     new_access_token = auth_service.issue_access_token(refresh_token)
-
     return {"access_token": new_access_token}
 
 @auth_router.post("/token/validate")
-def validate_token(
-    token: str = Depends(token_service.validate_token),
-    db: Session = Depends(get_db),  # noqa
-):
-    """
-    헤더에서 access_token을 받아와 토큰이 유효한지 검사하는 요청
-    """
-    is_expired = auth_service.validate_token(token=token, db=db)
+def validate_token(token: str):
+    is_valid = auth_service.validate_token(token)
 
-    if is_expired:
-        # 토큰이 유효하지 않거나 만료된 경우 예외를 발생
+    if not is_valid:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="토큰이 유효하지 않거나 만료되었습니다.",
         )
-        
     return Response(status_code=status.HTTP_200_OK)

--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -1,13 +1,16 @@
 from datetime import datetime
+from typing import Annotated
 
-from fastapi import APIRouter, Form, HTTPException, Request, status
+from fastapi import APIRouter, Form, HTTPException, Query, Request, status
 from fastapi.responses import RedirectResponse, Response
 
 from app.core import Config
 from app.dtos import naver
 from app.services import AuthService, NaverService, TokenService, UserService
 from app.utils import check_age, make_url
+import logging
 
+logger = logging.getLogger("auth_router")
 auth_router = APIRouter(tags=["auth"])
 
 auth_service = AuthService()
@@ -22,123 +25,141 @@ def auth_start():
     return RedirectResponse(url)
 
 @auth_router.get("/callback")
-async def auth_callback(code: str, state: str, request: Request):
+async def auth_callback(
+    code: Annotated[str, Query(description="네이버 인증 코드")],
+    state: Annotated[str, Query(description="네이버 인증 상태 값")],
+    request: Request
+):
+    try:
+        # 네이버 인증 처리 후 액세스 토큰을 가져오기
+        response = await naver_service.auth_callback(code, state)
+        access_token = response.get("access_token")
 
-    if not code:
-        raise HTTPException(status_code=400, detail="code가 제공되지 않았습니다.")
+        if not access_token:
+            raise HTTPException(status_code=400, detail="access_token이 필요합니다.")
 
-    if not state:
-        raise HTTPException(status_code=400, detail="state가 제공되지 않았습니다.")
+        generate_url = make_url(Config.CLIENT_URL)
 
-    # 네이버 인증 처리 후 액세스 토큰을 가져오기
-    response = await naver_service.auth_callback(code, state)
-    access_token = response.get("access_token")
+        # 네이버 사용자 정보를 가져오기
+        naver_user_info = await naver_service.user_me(access_token)
+        birthday = datetime.strptime(
+            f"{naver_user_info.birthyear}-{naver_user_info.birthday}", "%Y-%m-%d"
+        )
 
-    if not access_token:
-        raise HTTPException(status_code=400, detail="access_token이 필요합니다.")
+        # 사용자가 14세 미만인지 확인 후, 네이버 연동을 해제
+        if not check_age(birthday=birthday, age=14):
+            delete_result = await naver_service.delete_token(access_token)
 
-    generate_url = make_url(Config.CLIENT_URL)
+            if delete_result:
+                params = {"message": "14세 미만은 가입할 수 없습니다."}
+                url = generate_url("/login", params=params)
 
-    # 네이버 사용자 정보를 가져오기
-    naver_user_info = await naver_service.user_me(access_token)
-    birthday = datetime.strptime(
-        f"{naver_user_info.birthyear}-{naver_user_info.birthday}", "%Y-%m-%d"
-    )
+                response = RedirectResponse(url, status_code=301)
+                return response
 
-    # 사용자가 14세 미만인지 확인 후, 네이버 연동을 해제
-    if not check_age(birthday=birthday, age=14):
-        delete_result = await naver_service.delete_token(access_token)
+        # 사용자 이메일로 회원 정보 확인 및 처리
+        if user_service.user_exists(email=naver_user_info.email):
+            # 사용자 정보가 존재하면 액세스 토큰과 리프레시 토큰을 생성합니다.
+            access_token, refresh_token = auth_service.sign_in(naver_user_info)
 
-        if delete_result:
-            params = {"message": "14세 미만은 가입할 수 없습니다."}
+            params = {"access_token": access_token}
             url = generate_url("/login", params=params)
 
             response = RedirectResponse(url, status_code=301)
+            response.set_cookie(
+                key="refresh_token",
+                value=refresh_token,
+                httponly=True,
+                samesite="lax",
+            )
             return response
+        else:
+            try:
+                # 사용자 정보가 존재하지 않으면 회원가입을 처리
+                auth_service.sign_up(naver_user_info)
+            except Exception as e:
+                logger.error(f"회원가입 처리 중 오류 발생: {e}")
+                raise HTTPException(status_code=500, detail="회원가입에 실패했습니다.")
 
-    # 사용자 이메일로 회원 정보 확인 및 처리
-    if user_service.user_exists(email=naver_user_info.email):
-        # 사용자 정보가 존재하면 액세스 토큰과 리프레시 토큰을 생성합니다.
-        access_token, refresh_token = auth_service.sign_in(naver_user_info)
+            params = {"access_token": "", "code": code}
+            url = generate_url("/login", params=params)
 
-        params = {"access_token": access_token}
-        url = generate_url("/login", params=params)
-
-        response = RedirectResponse(url, status_code=301)
-        response.set_cookie(
-            key="refresh_token",
-            value=refresh_token,
-            httponly=True,
-            samesite="lax",
-        )
-        return response
-    else:
-        try:
-            # 사용자 정보가 존재하지 않으면 회원가입을 처리
-            auth_service.sign_up(naver_user_info)
-        except Exception as e:
-            raise HTTPException(status_code=500, detail="회원가입에 실패했습니다.")
-
-        params = {"access_token": "", "code": code}
-        url = generate_url("/login", params=params)
-
-        return RedirectResponse(url, status_code=301)
+            return RedirectResponse(url, status_code=301)
+    except Exception as e:
+        logger.error(f"Callback 처리 중 오류 발생: {e}")
+        raise HTTPException(status_code=500, detail="알 수 없는 오류가 발생했습니다.")
 
 @auth_router.post("/naver/user_info")
 def get_naver_user_info(dto: naver.NaverUserInfoWithCodeDTO, request: Request):
-    # 네이버 사용자 정보를 조회
-    code = dto.code
+    try:
+        # 네이버 사용자 정보를 조회
+        code = dto.code
 
-    if not code:
-        # code가 제공되지 않았을 경우 예외 발생
-        raise HTTPException(status_code=400, detail="code가 필요합니다.")
+        if not code:
+            # code가 제공되지 않았을 경우 예외 발생
+            raise HTTPException(status_code=400, detail="code가 필요합니다.")
 
-    naver_user_info: naver.NaverUserDTO = request.session.get(code)
+        naver_user_info: naver.NaverUserDTO = request.session.get(code)
 
-    if not naver_user_info:
-        # 세션이 만료되었거나 유효하지 않은 경우 예외 발생
-        raise HTTPException(
-            status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
-        )
+        if not naver_user_info:
+            # 세션이 만료되었거나 유효하지 않은 경우 예외 발생
+            raise HTTPException(
+                status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
+            )
 
-    return naver.NaverUserInfoWithEmailAndNameDTO(**naver_user_info)
+        return naver.NaverUserInfoWithEmailAndNameDTO(**naver_user_info)
+    except Exception as e:
+        logger.error(f"네이버 사용자 정보 조회 중 오류 발생: {e}")
+        raise HTTPException(status_code=500, detail="사용자 정보 조회에 실패했습니다.")
 
 @auth_router.post("/sign-up")
 def sign_up(request: Request, code: str = Form(...)):
-    naver_user_info: naver.NaverUserDTO = request.session.get(code)
+    try:
+        naver_user_info: naver.NaverUserDTO = request.session.get(code)
 
-    if not naver_user_info:
-        raise HTTPException(
-            status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
-        )
+        if not naver_user_info:
+            raise HTTPException(
+                status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
+            )
 
-    new_tribe_user = auth_service.sign_up(naver_user_info)
+        new_tribe_user = auth_service.sign_up(naver_user_info)
 
-    # 회원가입이 완료되면 세션을 초기화
-    request.session.clear()
+        # 회원가입이 완료되면 세션을 초기화
+        request.session.clear()
 
-    return new_tribe_user
+        return new_tribe_user
+    except Exception as e:
+        logger.error(f"회원가입 처리 중 오류 발생: {e}")
+        raise HTTPException(status_code=500, detail="회원가입에 실패했습니다.")
 
 @auth_router.post("/token/refresh")
 def refresh_token(request: Request):
-    refresh_token = request.cookies.get("refresh_token")
+    try:
+        refresh_token = request.cookies.get("refresh_token")
 
-    if not refresh_token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="토큰이 유효하지 않거나 만료되었습니다.",
-        )
+        if not refresh_token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="토큰이 유효하지 않거나 만료되었습니다.",
+            )
 
-    new_access_token = auth_service.issue_access_token(refresh_token)
-    return {"access_token": new_access_token}
+        new_access_token = auth_service.issue_access_token(refresh_token)
+        return {"access_token": new_access_token}
+    except Exception as e:
+        logger.error(f"토큰 갱신 중 오류 발생: {e}")
+        raise HTTPException(status_code=500, detail="토큰 갱신에 실패했습니다.")
 
 @auth_router.post("/token/validate")
 def validate_token(token: str):
-    is_valid = auth_service.validate_token(token)
+    try:
+        is_valid = auth_service.validate_token(token)
 
-    if not is_valid:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="토큰이 유효하지 않거나 만료되었습니다.",
-        )
-    return Response(status_code=status.HTTP_200_OK)
+        if not is_valid:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="토큰이 유효하지 않거나 만료되었습니다.",
+            )
+        return Response(status_code=status.HTTP_200_OK)
+    except Exception as e:
+        logger.error(f"토큰 검증 중 오류 발생: {e}")
+        raise HTTPException(status_code=500, detail="토큰 검증에 실패했습니다.")

--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -1,7 +1,11 @@
-from fastapi import APIRouter, Form, HTTPException, Request, status
-from fastapi.responses import RedirectResponse, Response
 from datetime import datetime
-from app.core import Config
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import RedirectResponse, Response
+from sqlalchemy.orm import Session
+
+from app.core import Config, get_db
+from app.core.database import session_scope
 from app.dtos import naver
 from app.services import AuthService, NaverService, TokenService, UserService
 from app.utils import check_age, make_url
@@ -15,39 +19,65 @@ token_service = TokenService()
 
 @auth_router.get("/start")
 def auth_start():
+    # 로그인 시작 시 네이버 인증 URL 생성 및 리다이렉트
     url = naver_service.auth_start()
     return RedirectResponse(url)
 
 @auth_router.get("/callback")
-async def auth_callback(code: str, state: str, request: Request):
-    if not code:
-        raise HTTPException(status_code=400, detail="code is not provided")
-    if not state:
-        raise HTTPException(status_code=400, detail="state is not provided")
+async def auth_callback(
+    code: str, state: str, request: Request, db: Session = Depends(get_db)
+):
+    with session_scope() as session:
+        # 세션 시작
+        pass
 
+    if not code:
+        # code가 제공되지 않았을 경우 예외를 발생
+        raise HTTPException(status_code=400, detail="code가 제공되지 않았습니다.")
+
+    if not state:
+        # state가 제공되지 않았을 경우 예외를 발생
+        raise HTTPException(status_code=400, detail="state가 제공되지 않았습니다.")
+
+    # 네이버 인증 처리 후 액세스 토큰을 가져오기
     response = await naver_service.auth_callback(code, state)
+
     access_token = response.get("access_token")
+
     if not access_token:
-        raise HTTPException(status_code=400, detail="access_token가 필요합니다.")
+        # 액세스 토큰이 없을 경우 예외를 발생
+        raise HTTPException(status_code=400, detail="access_token이 필요합니다.")
 
     generate_url = make_url(Config.CLIENT_URL)
+
+    # 네이버 사용자 정보를 가져옵니다.
     naver_user_info = await naver_service.user_me(access_token)
     birthday = datetime.strptime(
         f"{naver_user_info.birthyear}-{naver_user_info.birthday}", "%Y-%m-%d"
     )
 
+    # 사용자가 14세 미만인지 확인 후, 네이버 연동을 해제
     if not check_age(birthday=birthday, age=14):
         delete_result = await naver_service.delete_token(access_token)
+
+        # 네이버 연동 해제 성공 시 처리
         if delete_result:
             params = {"message": "14세 미만은 가입할 수 없습니다."}
-            url = generate_url("login", params={"access_token": "", "code": code})
-            return RedirectResponse(url, status_code=301)
+            url = generate_url("/login", params=params)
 
+        response = RedirectResponse(url, status_code=301)
+        return response
+
+    # 사용자 이메일로 회원 정보를 조회합니다.
     user_exist = user_service.user_exists(email=naver_user_info.email)
+
     if user_exist:
-        access_token, refresh_token = auth_service.sign_in(naver_user_info)
+        # 사용자 정보가 존재하면 액세스 토큰과 리프레시 토큰을 생성합니다.
+        access_token, refresh_token = auth_service.sign_in(naver_user_info, db)
+
         params = {"access_token": access_token}
-        url = generate_url("login", params=params)
+        url = generate_url("/login", params=params)
+
         response = RedirectResponse(url, status_code=301)
         response.set_cookie(
             key="refresh_token",
@@ -57,59 +87,99 @@ async def auth_callback(code: str, state: str, request: Request):
         )
         return response
     else:
+        # 사용자 정보가 존재하지 않으면 세션에 네이버 사용자 정보를 저장합니다.
         request.session[code] = naver_user_info.model_dump()
+
         params = {"access_token": "", "code": code}
-        url = generate_url("login", params=params)
-        return RedirectResponse(url, status_code=301)
+        url = generate_url("/login", params=params)
+
+        response = RedirectResponse(url, status_code=301)
+        return response
 
 @auth_router.post("/naver/user_info")
 def get_naver_user_info(dto: naver.NaverUserInfoWithCodeDTO, request: Request):
+    # 네이버 사용자 정보를 조회
     code = dto.code
+
     if not code:
+        # code가 제공되지 않았을 경우 예외를 발생
         raise HTTPException(status_code=400, detail="code가 필요합니다.")
+
     naver_user_info: naver.NaverUserDTO = request.session.get(code)
+
     if not naver_user_info:
+        # 세션이 만료되었거나 유효하지 않은 경우 예외를 발생
         raise HTTPException(
             status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
         )
+
+    # 사용자 정보를 성공적으로 반환
     return naver.NaverUserInfoWithEmailAndNameDTO(**naver_user_info)
 
 @auth_router.post("/sign-up")
-def sign_up(request: Request, code: str = Form(...)):
-    naver_user_info = request.session.get(code)
+def sign_up(
+    request: Request,
+    code: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    # 네이버 사용자 정보를 세션에서 가져오기
+    naver_user_info: naver.NaverUserDTO = request.session.get(code)
+
     if not naver_user_info:
+        # 세션이 만료되었거나 유효하지 않은 경우 예외를 발생
         raise HTTPException(
             status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
         )
+
+    # 회원가입 진행
     new_tribe_user = auth_service.sign_up(
-        naver.NaverUserDTO(**naver_user_info)
+        db, naver.NaverUserDTO(**naver_user_info)
     )
+
+    # 회원가입이 완료되면 세션을 초기화
     request.session.clear()
+
     return new_tribe_user
 
 @auth_router.post("/token/refresh")
-def refresh_token(request: Request):
-    refresh_token = request.cookies.get("refresh_token")
-    if not refresh_token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Refresh token이 필요합니다.",
-        )
-    is_expired = auth_service.validate_token(token=refresh_token)
+def refresh_token(
+    request: Request,
+    token: str = Depends(token_service.validate_token),
+    db: Session = Depends(get_db),
+):
+    """
+    요청 정보에서 refresh_token을 받아와 access_token을 갱신하는 요청
+    """
+    is_expired = auth_service.validate_token(token=token, db=db)
+
     if is_expired:
+        # 토큰이 유효하지 않거나 만료된 경우 예외를 발생
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="토큰이 유효하지 않거나 만료되었습니다.",
         )
+
+    # access_token을 다시 발급합니다.
+    refresh_token = request.cookies.get("refresh_token")
     new_access_token = auth_service.issue_access_token(refresh_token)
+
     return {"access_token": new_access_token}
 
 @auth_router.post("/token/validate")
-def validate_token(token: str):
-    is_expired = auth_service.validate_token(token=token)
+def validate_token(
+    token: str = Depends(token_service.validate_token),
+    db: Session = Depends(get_db),  # noqa
+):
+    """
+    헤더에서 access_token을 받아와 토큰이 유효한지 검사하는 요청
+    """
+    is_expired = auth_service.validate_token(token=token, db=db)
+
     if is_expired:
+        # 토큰이 유효하지 않거나 만료된 경우 예외를 발생
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="토큰이 유효하지 않거나 만료되었습니다.",
         )
+        
     return Response(status_code=status.HTTP_200_OK)

--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-
 from fastapi import APIRouter, Form, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, Response
+from datetime import datetime
 from app.core import Config
-from app.core.database import session_scope
 from app.dtos import naver
 from app.services import AuthService, NaverService, TokenService, UserService
 from app.utils import check_age, make_url
@@ -15,179 +13,103 @@ naver_service = NaverService()
 user_service = UserService()
 token_service = TokenService()
 
-
 @auth_router.get("/start")
 def auth_start():
     url = naver_service.auth_start()
-    print(f"[DEBUG] Redirecting to URL: {url}")
     return RedirectResponse(url)
-
 
 @auth_router.get("/callback")
 async def auth_callback(code: str, state: str, request: Request):
-    print(f"[DEBUG] Callback received with code: {code}, state: {state}")
     if not code:
-        print("[ERROR] Code is not provided")
         raise HTTPException(status_code=400, detail="code is not provided")
     if not state:
-        print("[ERROR] State is not provided")
         raise HTTPException(status_code=400, detail="state is not provided")
 
-    print("[DEBUG] Calling NaverService auth_callback...")
     response = await naver_service.auth_callback(code, state)
-    print(f"[DEBUG] Naver auth response: {response}")
-
     access_token = response.get("access_token")
     if not access_token:
-        print("[ERROR] Access token is missing in the response")
         raise HTTPException(status_code=400, detail="access_token가 필요합니다.")
 
-    print(f"[DEBUG] Access token received: {access_token}")
     generate_url = make_url(Config.CLIENT_URL)
-    print(f"[DEBUG] Generated URL: {generate_url}")
-
-    print("[DEBUG] Fetching user information from Naver...")
     naver_user_info = await naver_service.user_me(access_token)
-    print(f"[DEBUG] Naver user info: {naver_user_info}")
-
     birthday = datetime.strptime(
         f"{naver_user_info.birthyear}-{naver_user_info.birthday}", "%Y-%m-%d"
     )
-    print(f"[DEBUG] User birthday: {birthday}")
 
-    # 사용자가 14세 미만인지 확인
     if not check_age(birthday=birthday, age=14):
-        print("[DEBUG] User is under 14 years old, revoking token...")
         delete_result = await naver_service.delete_token(access_token)
         if delete_result:
-            print("[DEBUG] Token revoked successfully")
             params = {"message": "14세 미만은 가입할 수 없습니다."}
             url = generate_url("login", params={"access_token": "", "code": code})
-            print(f"[DEBUG] Redirecting to: {url}")
             return RedirectResponse(url, status_code=301)
 
-    print("[DEBUG] Checking if user exists in the database...")
-    with session_scope() as session:
-        user_exist = user_service.user_exists(session, email=naver_user_info.email)
-        print(f"[DEBUG] User exists: {user_exist}")
-
-        if user_exist:
-            print("[DEBUG] Signing in the user...")
-            access_token, refresh_token = auth_service.sign_in(naver_user_info, session)
-
-            params = {"access_token": access_token}
-            url = generate_url("login", params=params)
-            print(f"[DEBUG] Redirecting to: {url}")
-
-            response = RedirectResponse(url, status_code=301)
-            response.set_cookie(
-                key="refresh_token",
-                value=refresh_token,
-                httponly=True,
-                samesite="lax",
-            )
-            return response
-        else:
-            print("[DEBUG] User does not exist, redirecting to sign-up...")
-            request.session[code] = naver_user_info.model_dump()
-
-            params = {"access_token": "", "code": code}
-            url = generate_url("login", params=params)
-            print(f"[DEBUG] Redirecting to: {url}")
-
-            return RedirectResponse(url, status_code=301)
-
+    user_exist = user_service.user_exists(email=naver_user_info.email)
+    if user_exist:
+        access_token, refresh_token = auth_service.sign_in(naver_user_info)
+        params = {"access_token": access_token}
+        url = generate_url("login", params=params)
+        response = RedirectResponse(url, status_code=301)
+        response.set_cookie(
+            key="refresh_token",
+            value=refresh_token,
+            httponly=True,
+            samesite="lax",
+        )
+        return response
+    else:
+        request.session[code] = naver_user_info.model_dump()
+        params = {"access_token": "", "code": code}
+        url = generate_url("login", params=params)
+        return RedirectResponse(url, status_code=301)
 
 @auth_router.post("/naver/user_info")
 def get_naver_user_info(dto: naver.NaverUserInfoWithCodeDTO, request: Request):
     code = dto.code
-    print(f"[DEBUG] Received code: {code}")
-
     if not code:
-        print("[ERROR] Code is missing")
         raise HTTPException(status_code=400, detail="code가 필요합니다.")
-
     naver_user_info: naver.NaverUserDTO = request.session.get(code)
-    print(f"[DEBUG] Naver user info from session: {naver_user_info}")
-
     if not naver_user_info:
-        print("[ERROR] Session is expired or invalid")
         raise HTTPException(
             status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
         )
-
     return naver.NaverUserInfoWithEmailAndNameDTO(**naver_user_info)
-
 
 @auth_router.post("/sign-up")
 def sign_up(request: Request, code: str = Form(...)):
-    print(f"[DEBUG] Sign-up received with code: {code}")
     naver_user_info = request.session.get(code)
-    print(f"[DEBUG] Naver user info from session: {naver_user_info}")
-
     if not naver_user_info:
-        print("[ERROR] Session is expired or invalid")
         raise HTTPException(
             status_code=400, detail="세션이 만료되었거나 유효하지 않습니다."
         )
-
-    with session_scope() as session:
-        print("[DEBUG] Signing up user...")
-        new_tribe_user = auth_service.sign_up(
-            session, naver.NaverUserDTO(**naver_user_info)
-        )
-        print(f"[DEBUG] New user created: {new_tribe_user}")
-
-        print("[DEBUG] Clearing session...")
-        request.session.clear()
-
+    new_tribe_user = auth_service.sign_up(
+        naver.NaverUserDTO(**naver_user_info)
+    )
+    request.session.clear()
     return new_tribe_user
-
 
 @auth_router.post("/token/refresh")
 def refresh_token(request: Request):
-    print("[DEBUG] Refresh token endpoint called")
     refresh_token = request.cookies.get("refresh_token")
-    print(f"[DEBUG] Refresh token from cookies: {refresh_token}")
-
     if not refresh_token:
-        print("[ERROR] Refresh token is missing")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Refresh token이 필요합니다.",
         )
-
-    with session_scope() as session:
-        print("[DEBUG] Validating token...")
-        is_expired = auth_service.validate_token(token=refresh_token, db=session)
-
-        if is_expired:
-            print("[ERROR] Token is expired or invalid")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="토큰이 유효하지 않거나 만료되었습니다.",
-            )
-
-        new_access_token = auth_service.issue_access_token(refresh_token)
-        print(f"[DEBUG] New access token issued: {new_access_token}")
-
-        return {"access_token": new_access_token}
-
+    is_expired = auth_service.validate_token(token=refresh_token)
+    if is_expired:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="토큰이 유효하지 않거나 만료되었습니다.",
+        )
+    new_access_token = auth_service.issue_access_token(refresh_token)
+    return {"access_token": new_access_token}
 
 @auth_router.post("/token/validate")
 def validate_token(token: str):
-    print(f"[DEBUG] Validate token called with token: {token}")
-
-    with session_scope() as session:
-        print("[DEBUG] Validating token in the database...")
-        is_expired = auth_service.validate_token(token=token, db=session)
-
-        if is_expired:
-            print("[ERROR] Token is expired or invalid")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="토큰이 유효하지 않거나 만료되었습니다.",
-            )
-
-        print("[DEBUG] Token is valid")
-        return Response(status_code=status.HTTP_200_OK)
+    is_expired = auth_service.validate_token(token=token)
+    if is_expired:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="토큰이 유효하지 않거나 만료되었습니다.",
+        )
+    return Response(status_code=status.HTTP_200_OK)

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -19,16 +19,19 @@ class Database:
 
     engine = create_engine(
         SQLALCHEMY_DATABASE_URL,
-        pool_pre_ping=True,  # 연결 유효성 미리 확인
-        pool_recycle=3600,  # 1시간(3600초)마다 연결 재생성
+        pool_pre_ping=True,
+        pool_recycle=3600,
     )
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
     Base = declarative_base()
+
+    @staticmethod
+    def get_session():
+        return Database.SessionLocal()
 
 
 def get_db():
-    db = Database.SessionLocal()
+    db = Database.get_session()
     try:
         yield db
     finally:
@@ -51,15 +54,12 @@ def db(func):
 @contextmanager
 def session_scope():
     """Provide a transactional scope around a series of operations."""
-
-    database = Database()
-    session = database.get_session()
+    session = Database.get_session()
     db_session_context.set(session)
     try:
         yield session
         session.commit()
     except Exception as exc:
-        # db 에러 체크
         print(exc)
         session.rollback()
         raise exc

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,8 +1,17 @@
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import wraps
+from typing import Optional
+
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from .config import Config
+
+db_session_context: ContextVar[Optional[int]] = ContextVar(
+    "db_session_context", default=None
+)
 
 
 class Database:
@@ -28,3 +37,32 @@ def get_db():
 
 def bootstrap():
     Database.Base.metadata.create_all(bind=Database.engine)
+
+
+def db(func):
+    @wraps(func)
+    def wrap_func(*args, **kwargs):
+        db_session = db_session_context.get()
+        return func(*args, **kwargs, session=db_session)
+
+    return wrap_func
+
+
+@contextmanager
+def session_scope():
+    """Provide a transactional scope around a series of operations."""
+
+    database = Database()
+    session = database.get_session()
+    db_session_context.set(session)
+    try:
+        yield session
+        session.commit()
+    except Exception as exc:
+        # db 에러 체크
+        print(exc)
+        session.rollback()
+        raise exc
+    finally:
+        session.close()
+        db_session_context.set(None)

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -45,9 +45,9 @@ def bootstrap():
 def db(func):
     @wraps(func)
     def wrap_func(*args, **kwargs):
-        db_session = db_session_context.get()
-        return func(*args, **kwargs, session=db_session)
-
+        with session_scope() as session:
+            kwargs['db'] = session
+            return func(*args, **kwargs)
     return wrap_func
 
 

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -60,7 +60,6 @@ def session_scope():
         yield session
         session.commit()
     except Exception as exc:
-        print(exc)
         session.rollback()
         raise exc
     finally:

--- a/app/models/user_model.py
+++ b/app/models/user_model.py
@@ -8,8 +8,8 @@ from app.enums import GenderType
 class User(Database.Base):
     __tablename__ = "user"
 
-    id = Column(Integer, primary_key=True, index=True)
-    uid = Column(String, primary_key=True)
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    uid = Column(String, unique=True, nullable=False)
     created_at = Column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/app/repositories/auth/auth_repository.py
+++ b/app/repositories/auth/auth_repository.py
@@ -9,8 +9,6 @@ class AuthRepository:
             .filter(User.uid == uid)
             .update({"refresh_token": refresh_token})
         )
-        db.commit()
-
         return result > 0
 
     def sign_up(self, db: Session, user_model: User):
@@ -20,10 +18,7 @@ class AuthRepository:
         """
         try:
             db.add(user_model)
-            db.commit()
-
         except Exception as e:
-            db.rollback()  # 예외 발생 시 롤백
             raise
 
         return True

--- a/app/repositories/auth/auth_repository.py
+++ b/app/repositories/auth/auth_repository.py
@@ -1,7 +1,5 @@
 from sqlalchemy.orm import Session
-
 from app.models import User
-
 
 class AuthRepository:
 
@@ -20,9 +18,13 @@ class AuthRepository:
         네이버 회원정보를 가지고 트라이브 회원으로 가입합니다.
         :return: 가입한 회원 정보
         """
+        try:
+            db.add(user_model)
+            db.commit()
 
-        db.add(user_model)
-        db.commit()
+        except Exception as e:
+            db.rollback()  # 예외 발생 시 롤백
+            raise
 
         return True
 

--- a/app/services/auth/auth_service.py
+++ b/app/services/auth/auth_service.py
@@ -3,6 +3,7 @@ from jwt.exceptions import InvalidTokenError
 from sqlalchemy.orm import Session
 
 from app.core import Config, Token
+from app.core.database import session_scope
 from app.dtos import auth, naver, user
 from app.enums import GenderType
 from app.models import User
@@ -13,65 +14,68 @@ from .token_service import TokenService
 
 ALGORITHM = "HS256"
 
-
 class AuthService:
     def __init__(self):
         self.token_service = TokenService()
         self.auth_repository = AuthRepository()
         self.token = Token()
 
-    def sign_in(self, naver_user_info: naver.NaverUserDTO, db: Session):
+    def sign_in(self, naver_user_info: naver.NaverUserDTO):
         """
         로그인 처리 로직
         """
+        with session_scope() as db:  # 세션 관리 시작
+            data = {"sub": naver_user_info.id}
 
-        data = {"sub": naver_user_info.id}
+            access_token = self.token_service.create_jwt_token(
+                data, expires_delta=self.token.ACCESS_TOKEN_DURATION
+            )
+            refresh_token = self.token_service.create_jwt_token(
+                data, expires_delta=self.token.REFRESH_TOKEN_DURATION
+            )
 
-        access_token = self.token_service.create_jwt_token(
-            data, expires_delta=self.token.ACCESS_TOKEN_DURATION
-        )
-        refresh_token = self.token_service.create_jwt_token(
-            data, expires_delta=self.token.REFRESH_TOKEN_DURATION
-        )
+            is_signed_in = self.auth_repository.sign_in(
+                uid=naver_user_info.id, refresh_token=refresh_token, db=db
+            )
 
-        is_signed_in = self.auth_repository.sign_in(
-            uid=naver_user_info.id, refresh_token=refresh_token, db=db
-        )
+            if not is_signed_in:
+                raise HTTPException(status_code=500, detail="로그인을 할 수 없습니다.")
 
-        if not is_signed_in:
-            raise HTTPException(status_code=500, detail="로그인을 할 수 없습니다.")
+            return access_token, refresh_token
 
-        return access_token, refresh_token
+    def sign_up(self, naver_user_info: naver.NaverUserDTO):
+        """
+        회원가입 처리 로직
+        """
+        with session_scope() as db:  # 세션 관리 시작
+            uid = naver_user_info.id
 
-    def sign_up(self, db: Session, naver_user_info: naver.NaverUserDTO):
-        uid = naver_user_info.id
+            user_info = user.UserDTO(
+                uid=uid,
+                email=naver_user_info.email,
+                name=naver_user_info.name,
+                birthday=create_timestamptz(
+                    birthyear=naver_user_info.birthyear, birthday=naver_user_info.birthday
+                ),
+                service_agreement=False,
+                privacy_consent=False,
+                age_consent=False,
+                marketing_agreement=False,
+                provider="naver",
+                gender=GenderType(naver_user_info.gender),
+                image_url=None,
+                introduction=None,
+                refresh_token=None,
+                deactivated=False,
+            ).model_dump(exclude_unset=True)
+            user_model = User(**user_info)
 
-        user_info = user.UserDTO(
-            uid=uid,
-            email=naver_user_info.email,
-            name=naver_user_info.name,
-            birthday=create_timestamptz(
-                birthyear=naver_user_info.birthyear, birthday=naver_user_info.birthday
-            ),
-            service_agreement=False,
-            privacy_consent=False,
-            age_consent=False,
-            marketing_agreement=False,
-            provider="naver",
-            gender=GenderType(naver_user_info.gender),
-            image_url=None,
-            introduction=None,
-            refresh_token=None,
-            deactivated=False,
-        ).model_dump(exclude_unset=True)
-        user_model = User(**user_info)
+            is_signed_up = self.auth_repository.sign_up(db, user_model)
 
-        is_signed_up = self.auth_repository.sign_up(db, user_model)
+            if not is_signed_up:
+                raise HTTPException(status_code=500, detail="회원가입에 실패했습니다.")
 
-        if not is_signed_up:
-            raise HTTPException(status_code=500, detail="회원가입에 실패했습니다.")
-
-        return user_info
+            return user_info
 
     def issue_access_token(self, refresh_token: str):
         """
@@ -88,34 +92,34 @@ class AuthService:
 
             return new_access_token
         except InvalidTokenError:
-            raise InvalidTokenError
+            raise HTTPException(status_code=401, detail="리프레시 토큰이 유효하지 않습니다.")
 
-    def validate_token(self, token: auth.Token, db: Session):
+    def validate_token(self, token: auth.Token):
         """
         토큰 값이 유효한지 확인하는 함수입니다.
         """
-        try:
-            payload = self.token_service.decode_token(token)
-            uid: str = payload.get("sub")
-        except InvalidTokenError:
-            return False
+        with session_scope() as db:  # 세션 관리 시작
+            try:
+                payload = self.token_service.decode_token(token)
+                uid: str = payload.get("sub")
+            except InvalidTokenError:
+                return False
 
-        user_info = self.auth_repository.find_user_by_id(uid, db)
+            user_info = self.auth_repository.find_user_by_id(uid, db)
 
-        if not user_info:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="토큰이 유효하지 않습니다.",
-            )
+            if not user_info:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="토큰이 유효하지 않습니다.",
+                )
 
-        # refresh_token이 유효한지 확인
-        refresh_token = user_info.refresh_token
+            # refresh_token이 유효한지 확인
+            refresh_token = user_info.refresh_token
 
-        try:
-            refresh_token_payload = self.token_service.decode_token(refresh_token)
-        except InvalidTokenError:
-            raise False
+            try:
+                refresh_token_payload = self.token_service.decode_token(refresh_token)
+            except InvalidTokenError:
+                return False
 
-        exp = refresh_token_payload.get("exp")
-
-        return self.token_service.is_token_expired(exp)
+            exp = refresh_token_payload.get("exp")
+            return not self.token_service.is_token_expired(exp)

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,11 +1,11 @@
 from sqlalchemy.orm import Session
-
 from app.repositories import UserRepository
-
+from app.core.database import db
 
 class UserService:
     def __init__(self):
         self.user_repository = UserRepository()
 
+    @db
     def user_exists(self, db: Session, email: str):
         return self.user_repository.user_exists_by_email(db, email)

--- a/app/utils/url.py
+++ b/app/utils/url.py
@@ -1,16 +1,17 @@
 from urllib.parse import urlencode
 
-
 def make_url(url):
     def combine_url(pathname, **kwargs):
+        # url 끝 슬래시 제거, pathname 시작 슬래시 제거 후 결합
+        base_path = f"{url.rstrip('/')}/{pathname.lstrip('/')}"
         query_string = ""
 
-        if kwargs["params"]:
+        if kwargs.get("params"):  # params가 존재하는 경우
             query_string = urlencode(kwargs["params"])
 
         if query_string:
-            return f"{url}/{pathname}?{query_string}"
+            return f"{base_path}?{query_string}"
 
-        return f"{url}/{pathname}"
+        return base_path
 
     return combine_url


### PR DESCRIPTION
[![TRIBE-79](https://badgen.net/badge/JIRA/TRIBE-79/green?icon=jira)](https://tribe-forus.atlassian.net/browse/TRIBE-79) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tribe-org&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 📝 작업 내용

## 컨트롤러와 서비스 계층 역할 분리
- 컨트롤러에서 `session_scope` 사용 제거
- 데이터베이스 세션 관리는 `AuthService`에서 처리하도록 리팩터링
- 컨트롤러는 요청 처리 및 서비스 호출에만 집중하도록 역할 분리

## `make_url` 함수 개선
- URL 끝 슬래시와 pathname 시작 슬래시가 중복되는 문제를 해결
- URL 생성 시 불필요한 중복 슬래시를 제거하여 올바른 URL 반환

# 🔍 작업 이유

## 코드의 역할 분리 및 유지보수성 향상
- 컨트롤러와 서비스 계층 간의 책임을 명확히 분리하여 가독성과 유지보수성을 높이기 위함
- 세션 관리를 컨트롤러에서 제거함으로써, 컨트롤러가 서비스 호출과 응답 처리에만 집중하도록 개선

## 중복된 슬래시 문제 해결
- 기존 `make_url` 함수에서 URL 끝과 pathname 시작에 중복된 슬래시가 포함되는 문제 해결
- URL 처리 로직 개선으로 API 호출 및 리다이렉트 시 발생할 수 있는 잠재적 오류 방지

# ✅ 기대 효과
- 코드의 모듈화와 역할 분리로 유지보수와 확장성 용이
- URL 생성 로직 개선으로 중복 슬래시로 인한 오류 제거


[TRIBE-79]: https://tribe-forus.atlassian.net/browse/TRIBE-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ